### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/PR008-RelativeLayout/app/src/main/AndroidManifest.xml
+++ b/PR008-RelativeLayout/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
           package="es.iessaladillo.pedrojoya.pr008" >
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
For allow: Backup always set to false if it is true, this is considered a security issue because people could backup your app via ADB and then get private data of your app into their PC.